### PR TITLE
Fixed the interval from five to two

### DIFF
--- a/Lab-4-Artifacts/lab4-detailed-steps.md
+++ b/Lab-4-Artifacts/lab4-detailed-steps.md
@@ -32,7 +32,7 @@ In this task you will create a new Task definition that will run the image asses
 
 ## 4.2 Create a scheduled ECS task.
 
-In this task you will create a scheduled ECS task which executes every five minutes:
+In this task you will create a scheduled ECS task which executes every two minutes:
 
 1. In the AWS Console, in the **Compute** section click **ECS**.
 


### PR DESCRIPTION
The text said "five" but the actual value below was "2".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
