### PR TITLE
The high-level instructions missed an instruction

### DIFF
--- a/Lab-3-Artifacts/README.md
+++ b/Lab-3-Artifacts/README.md
@@ -5,7 +5,7 @@ In order to accomplish this, the location of the unicorn images will be stored i
 In this lab, you will configure Parameter Store and deploy a new version of the cats task that can access the Parameter Store secure string.
 
 ### High-level Instructions
-1.	In Systems Manager Parameter Store (located in the EC2 console), create a new secure string. Name the secure string **UnicornLocation** and use the default KMS key. Enter a value of **catsndogs-assets.s3.amazonaws.com**
+1.	In Systems Manager Parameter Store (located in the EC2 console), create a new secure string. Name the secure string **UnicornLocation** and use the default KMS key. Enter a value of **catsndogs-assets.s3.amazonaws.com**. Add a tag with the key "Classification" and value "Mythical" (no quotes).
 
 2.	In the ECS Task Definition create a new revision of the cats task:
 


### PR DESCRIPTION
The high level didn't contain the tag classification, which appears in the detailed instructions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
